### PR TITLE
Seems to fix utf-8 problems when checking php code with accents

### DIFF
--- a/sublimelinter/modules/php.py
+++ b/sublimelinter/modules/php.py
@@ -16,9 +16,8 @@ def check(codeString, filename):
                                 stdout=subprocess.PIPE,
                                 startupinfo=info)
 
-    plainText = codeString.encode("ascii", 'ignore')
     try:
-        result = process.communicate(plainText)[0]
+        result = process.communicate(codeString)[0]
     except:
         return False
     finally:


### PR DESCRIPTION
Seems to fix utf-8 problems when checking php code with accents (i tested it with my wordpress themes and they seems to be working fine).
