### PR TITLE
Lint support for haskell

### DIFF
--- a/sublimelinter/modules/haskell.py
+++ b/sublimelinter/modules/haskell.py
@@ -1,4 +1,4 @@
-# ruby.py - sublimelint package for checking ruby files
+# haskell.py - sublimelint package for checking haskell files
 
 import subprocess
 import sublime


### PR DESCRIPTION
Uses the standard Haskell lint tool (hlint) to provide Haskell lint support. hlint must be given a file name (rather than reading from stdin) so the current buffer is saved to a temporary file to provide continuous linting. Hopefully in the future hlint will be able to read from stdin, but my testing indicates that the performance hit isn't terrible.
