### PR TITLE
fixed coffescript linter for windows to use coffee.cmd

### DIFF
--- a/sublimelinter/modules/coffeescript.py
+++ b/sublimelinter/modules/coffeescript.py
@@ -2,12 +2,13 @@
 # coffeescript.py - sublimelint package for checking coffee files
 
 import re
+import os
 
 from base_linter import BaseLinter
 
 CONFIG = {
     'language': 'coffeescript',
-    'executable': 'coffee',
+    'executable': 'coffee.cmd' if os.name == 'nt' else 'coffee',
     'lint_args': '-l'
 }
 


### PR DESCRIPTION
With this change, whe running the linter in windows it will look for the file coffee.cmd instead of just "coffee" in the path. 

Thank you very much for your time.
