### PR TITLE
Changed the gutter cross to varying sizes of dot or circle based on severity.

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -31,6 +31,12 @@ DELAYS = (
     (1600, (1600, 3000)),
 )
 
+MARKS = {
+    "violation": ("", "dot"),
+    "warning": ("", "dot"),
+    "illegal": ("", "circle"),
+}
+
 
 def get_delay(t, view):
     delay = 0
@@ -103,7 +109,8 @@ def add_lint_marks(view, lines, error_underlines, violation_underlines, warning_
         view.add_regions('lint-underline-illegal', error_underlines, 'invalid.illegal', sublime.DRAW_EMPTY_AS_OVERWRITE)
     if lines:
         fill_outlines = view.settings().get('sublimelinter_fill_outlines', False)
-        gutter_mark = 'cross' if view.settings().get('sublimelinter_gutter_marks', False) else ''
+        gutter_mark_enabled = True if view.settings().get('sublimelinter_gutter_marks', False) else False
+
         outlines = {'warning': [], 'violation': [], 'illegal': []}
 
         for line in lines:
@@ -120,7 +127,7 @@ def add_lint_marks(view, lines, error_underlines, violation_underlines, warning_
                     'lint-outlines-{0}'.format(lint_type),
                     outlines[lint_type],
                     'sublimelinter.{0}'.format(lint_type),
-                    gutter_mark
+                    MARKS[lint_type][gutter_mark_enabled]
                 ]
                 if not fill_outlines:
                     args.append(sublime.DRAW_OUTLINED)


### PR DESCRIPTION
The gutter mark also inherits color from the theme based on scope.

I found the cross useless with the dark themes since the cross does not inherit its shade from the theme so it is always black.

The patch uses both dot (small) and circle (large) to draw more attention to more severe items.
