### PR TITLE
The javascript.py has a hardcoded 1 in the indent section.

### DIFF
--- a/sublimelinter/modules/javascript.py
+++ b/sublimelinter/modules/javascript.py
@@ -35,9 +35,7 @@ class Linter(BaseLinter):
         path = self.jshint_path()
 
         if self.jshint_options is None:
-            jshint_options = view.settings().get("jshint_options") or {}
-            jshint_options['indent'] = jshint_options.get('indent', 1)
-            self.jshint_options = json.dumps(jshint_options)
+            self.jshint_options = json.dumps(view.settings().get("jshint_options") or {})
 
         if self.use_jsc:
             args = (os.path.join(path, 'jshint_jsc.js'), '--', str(code.count('\n')), self.jshint_options, path + os.path.sep)


### PR DESCRIPTION
This might be okay if you are using tabs, but if you are using spaces you need to be able to override this. My change makes it easy for someone to set this in there conf file.
