### PR TITLE
Haskell support and fix for non-STDIN inputs

### DIFF
--- a/Base File.sublime-settings
+++ b/Base File.sublime-settings
@@ -28,7 +28,6 @@
     */
     "sublimelinter_executable_map":
     {
-        "haskell": "/Users/dever/Library/haskell/bin/hlint"
     },
 
     /*

--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -97,10 +97,9 @@ class BaseLinter(object):
 
         if isinstance(self.lint_args, basestring):
             self.lint_args = (self.lint_args,)
-        
+
         if self.input_method is not INPUT_METHOD_STDIN and self.lint_args is None:
             self.lint_args = ('{filename}',)
-
 
     def check_enabled(self, view):
         if hasattr(self, 'get_executable'):


### PR DESCRIPTION
1) Adds support for linting Haskell files.
    Note: Only has support for where hlint is on $PATH and on OS X w/Haskell Platform, but this is easy enough remedied once it's being used.

2) Fixes an issue with the likes of INPUT_METHOD_TEMPORARY_FILE. If this method or INPUT_METHOD_FILE was used, without an argument, it wouldn't work. This way if there's nothing specified it defaults to '{filename}'
