### PR TITLE
Change to PHP lint regex

### DIFF
--- a/sublimelinter/modules/php.py
+++ b/sublimelinter/modules/php.py
@@ -15,7 +15,7 @@ CONFIG = {
 class Linter(BaseLinter):
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         for line in errors.splitlines():
-            match = re.match(r'^Parse error:\s*(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
+            match = re.match(r'^Parse error:\s*(?:syntax error,\s*)?(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
 
             if match:
                 error, line = match.group('error'), match.group('line')


### PR DESCRIPTION
On my system (OS X 10.7 w/stock PHP 5.3.8), the PHP lint frequently
misses errors due to over-specificity in the regex. This one is
catching them. So far this is not tested with earlier PHP versions.
