### PR TITLE
PHP: Exeception matching regex on OSX

### DIFF
--- a/sublimelinter/modules/php.py
+++ b/sublimelinter/modules/php.py
@@ -16,6 +16,8 @@ class Linter(BaseLinter):
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         for line in errors.splitlines():
             match = re.match(r'^Parse error:\s*syntax error,\s*(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
+            if not match:
+            	match = re.match(r'^Parse error:\s*(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
 
             if match:
                 error, line = match.group('error'), match.group('line')


### PR DESCRIPTION
User @chipotle resports that the regexp for PHP is not working and fixed the issue with the following patch

https://github.com/chipotle/SublimeLinter/commit/2799b5f2cf9222313ccfe70d0663070a9950788a

This is a pull request to catch this.
