### PR TITLE
Index out of range - regions are dropping off

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -222,7 +222,12 @@ class BaseLinter(object):
         position += line.begin()
 
         for i in xrange(length):
-            underlines.append(sublime.Region(position + i))
+            # Create a transport dict to flag underlines as real/char-expanded
+            underline = {
+                'is_real': i == 0,
+                'region': sublime.Region(position + i),
+            }
+            underlines.append(underline)
 
     def underline_regex(self, view, lineno, regex, lines, underlines, wordmatch=None, linematch=None):
         # Assume lineno is one-based, ST2 wants zero-based line numbers


### PR DESCRIPTION
It looks like some regions are dropping off; possibly during `add_regions` dupes are getting resolved.

Given the JS file:

```
var Product: {
    ProdData: ""
};
```

Stack trace (from Sublime console):

```
SublimeLinter: javascript enabled (using JavaScriptCore)
Traceback (most recent call last):
  File "./sublime_plugin.py", line 190, in on_post_save
  File "./sublime_plugin.py", line 154, in run_timed_function
  File "./sublime_plugin.py", line 189, in <lambda>
  File "./SublimeLinter.py", line 627, in on_post_save
  File "./SublimeLinter.py", line 84, in background_run
  File "./SublimeLinter.py", line 109, in run_once
  File "./SublimeLinter.py", line 133, in popup_error_list
IndexError: list index out of range
```

Two lint messages are found by the linter; the region list should be `[(11, 11), (11, 11)]`, but only `[(11, 11)]` is returned when `view.get_regions` gets called.

I've added a `REGIONS` map to save regions as they are found instead of trying to pull them back via `view.get_regions`.
