### PR TITLE
Add "save-only" linter mode to avoid load-time linting.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -20,6 +20,11 @@
         "args": {"action": "load-save"}
     },
     {
+        "caption": "SublimeLinter: Enable Save-Only Linting",
+        "command": "sublimelinter_enable_save_only",
+        "args": {"action": "save-only"}
+    },
+    {
         "caption": "SublimeLinter: Disable Background Linting",
         "command": "sublimelinter_disable",
         "args": {"action": "off"}

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ SublimeLinter runs in one of three modes, which is determined by the "sublimelin
 
 * **Background mode (the default)** - When the "sublimelinter" setting is true, linting is performed in the background as you modify a file (if the relevant linter supports it). If you like instant feedback, this is the best way to use SublimeLinter. If you want feedback, but not instantly, you can try another mode or set a minimum queue delay so that the linter will only run after a certain amount of idle time.
 * **Load-save mode** - When the "sublimelinter" setting is "load-save", linting is performed only when a file is loaded and after saving. Errors are cleared as soon as the file is modified.
+* **Save-only mode** - When the "sublimelinter" setting is "save-only", linting is performed only after a file is saved. Errors are cleared as soon as the file is modified.
 * **On demand mode** - When the "sublimelinter" setting is false, linting is performed only when initiated by you. Use the Control+Command+l (OS X) or Control+Alt+l (Linux/Windows) key equivalent or the Command Palette to lint the current file. If the current file has no associated linter, the command will not be available.
 
 Within a file whose language/syntax is supported by SublimeLinter, you can control SublimeLinter via the Command Palette (Command+Shift+P on OS X, Control+Shift+P on Linux/Windows). The available commands are:
@@ -59,6 +60,7 @@ Within a file whose language/syntax is supported by SublimeLinter, you can contr
 * **SublimeLinter: Enable Background Linting** - Enables background linting mode for the current view and lints it.
 * **SublimeLinter: Disable Background Linting** - Disables background linting mode for the current view and clears all lint errors.
 * **SublimeLinter: Enable Load-Save Linting** - Enables load-save linting mode for the current view and clears all lint errors.
+* **SublimeLinter: Enable Save-Only Linting** - Enables save-only linting mode for the current view and clears all lint errors.
 * **SublimeLinter: Reset** - Clears all lint errors and sets the linting mode to the value in the SublimeLinter.sublime-settings file.
 
 Depending on the file and the current state of background enabling, some of the commands will not be available.

--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -616,6 +616,8 @@ class LintCommand(sublime_plugin.TextCommand):
             self.on()
         elif lc_action == 'load-save':
             self.enable_load_save()
+        elif lc_action == 'save-only':
+            self.enable_save_only()
         elif lc_action == 'off':
             self.off()
         elif action.lower() in LINTERS:
@@ -634,6 +636,11 @@ class LintCommand(sublime_plugin.TextCommand):
     def enable_load_save(self):
         '''Turns load-save linting on.'''
         self.view.settings().set('sublimelinter', 'load-save')
+        erase_lint_marks(self.view)
+
+    def enable_save_only(self):
+        '''Turns save-only linting on.'''
+        self.view.settings().set('sublimelinter', 'save-only')
         erase_lint_marks(self.view)
 
     def off(self):
@@ -680,7 +687,7 @@ class BackgroundLinter(sublime_plugin.EventListener):
     def on_load(self, view):
         reload_settings(view)
 
-        if view.is_scratch() or view.settings().get('sublimelinter') == False:
+        if view.is_scratch() or view.settings().get('sublimelinter') == False or view.settings().get('sublimelinter') == 'save-only':
             return
 
         background_run(select_linter(view), view, event='on_load')
@@ -874,6 +881,19 @@ class SublimelinterEnableLoadSaveCommand(SublimelinterCommand):
             view = self.window.active_view()
 
             if view and view.settings().get('sublimelinter') == 'load-save':
+                return False
+
+        return enabled
+
+
+class SublimelinterEnableSaveOnlyCommand(SublimelinterCommand):
+    def is_enabled(self):
+        enabled = super(SublimelinterEnableSaveOnlyCommand, self).is_enabled()
+
+        if enabled:
+            view = self.window.active_view()
+
+            if view and view.settings().get('sublimelinter') == 'save-only':
                 return False
 
         return enabled


### PR DESCRIPTION
Load-time linting can cause sluggishness when file previews kicks in (during "Goto anything" navigation, for instance). I'm not sure if there is a better way to only lint after a file is actually loaded into a solid buffer, but personally I don't need load-time linting as I generally assume there to be no errors on load.

Please pull if you see fit :).
