### PR TITLE
README file is .md not .rst

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -21,7 +21,7 @@ For more information:
 ---------------------
 Please take the time to read the documentation:
 
-* Online - https://github.com/Kronuz/SublimeLinter/blob/master/README.rst
+* Online - https://github.com/Kronuz/SublimeLinter/blob/master/README.md
 * Sublime Text - Select Preferences->Package Settings->SublimeLinter->README
 
 


### PR DESCRIPTION
Also, Preferences->Package Settings->SublimeLinter->README tries to open README.rst (so opens a new empty file), rather than the correct .md file.
