### PR TITLE
Readme is *still* .md

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -17,7 +17,7 @@
                         [
                             {
                                 "command": "open_file",
-                                "args": {"file": "${packages}/SublimeLinter/README.rst"},
+                                "args": {"file": "${packages}/SublimeLinter/README.md"},
                                 "caption": "README"
                             },
                             {


### PR DESCRIPTION
See e0adea831d7d1588f105a1f22dcff31b8b619e98 (change to Markdown)
See also 70e29a4edebd32db30ae42496e95711009fb5df8

I used the readme only yesterday (via menu), that's why I tested this at first when I read about the change to Markdown. Seems I was right considering this to be easy-forgettable.

Edit: Just saw that #157 actually mentioned this. Well, just pull then and all done.
