### PR TITLE
JSHint/JSLint: Underline the correct characters when using tabs

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -77,6 +77,7 @@
     // By deault, eval is allowed.
     "jshint_options":
     {
+        "indent": 1,
         "evil": true,
         "regexdash": true,
         "browser": true,


### PR DESCRIPTION
When using tabs for indentation (as opposed to spaces), the wrong characters are underlined. As an easy fix, set the JSHint option `indent` to `1` in order to make JSHint consider the tab to be _one_ character.
