### PR TITLE
Improve git commit message linter

### DIFF
--- a/sublimelinter/modules/git_commit_message.py
+++ b/sublimelinter/modules/git_commit_message.py
@@ -67,7 +67,7 @@ class Linter(BaseLinter):
                             'lineno': real_lineno,
                         })
             elif first_line_of_body is None:
-                if len(line) and not line.startswith('#'):
+                if len(line):
                     first_line_of_body = lineno
 
                     if lineno == first_line_of_message + 1:


### PR DESCRIPTION
For SublimeLinter/SublimeLinter#201

Ignores all lines after one starting with `diff --git`, which matches the behavior of git when used with `git commit -v`, which is excellent for viewing a diff while writing your commit message.

Also added a 2-tiered check for subject length—the original article referenced (http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) says "As the example indicates, you should shoot for about 50 characters (though this isn’t a hard maximum)..." — a more useful hard maximum is 68, since that's where github truncates the subject. 50 is left as a warning as it is still a useful recommendation.

In addition, based on my experience with `git commit -v` (which adds about 8 lines of comments below the first line—see example in SublimeLinter/SublimeLinter#201) I've added a check for a comment on the body text. It should be ignored if a comment hashmark is present.
