### PR TITLE
Fixed CSSLint.

### DIFF
--- a/sublimelinter/modules/libs/csslint/csslint-node.js
+++ b/sublimelinter/modules/libs/csslint/csslint-node.js
@@ -9124,3 +9124,5 @@ CSSLint.addFormatter({
 
 return CSSLint;
 })();
+
+exports.CSSLint = CSSLint;


### PR DESCRIPTION
`exports.CSSLint = CSSLint;` was missing, so CSSLint didn't work properly. 
