### PR TITLE
fix for issue #212; avoid sending code in communicate()

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -203,7 +203,8 @@ class BaseLinter(object):
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT,
                                        startupinfo=self.get_startupinfo())
-            result = process.communicate(code)[0]
+            process.stdin.write(code)
+            result = process.communicate()[0]
         finally:
             if tempfilePath:
                 os.remove(tempfilePath)


### PR DESCRIPTION
I managed to reproduce the crash from #212 in a separate program: https://gist.github.com/3885571

Warning: I'm not a pythonist, and I have no idea why the code didn't work in the first place (and it's fixed in Python 2.7). But the fix is straightforward and it works.

To find the issue, I commented out all of the SublimeLinter code and progressively uncommented parts of it until the crash appeared.
