### PR TITLE
Support for JSLint "globals" directive

### DIFF
--- a/sublimelinter/modules/libs/jshint/linter.js
+++ b/sublimelinter/modules/libs/jshint/linter.js
@@ -4,7 +4,7 @@
 var JSHINT = require("./jshint").JSHINT;
 
 exports.lint = function (code, config) {
-    var globals = {},
+    var globals,
         results = [];
 
     if (config.globals) {


### PR DESCRIPTION
`predef` is a legacy directive that is no longer [documented](http://www.jshint.com/docs/). 

`globals` is the third, optional parameter to `JSHINT`.  It should be undefined or an object with its keys being the global and value either `true` (overridable) or `false` (read-only).

This should allow `.jshintrc` or user settings with a "globals" option to work properly without warnings.  Example config:

``` JSON
{
    "browser": true,
    "undef": true,
    "globals":  {
        "cats": true,
        "dogs": false
    }
}
```

``` JavaScript
cats = dogs; // OK

dogs = cats; // Warning: Read only
```
