### PR TITLE
extract missing symbol info for java module

### DIFF
--- a/sublimelinter/modules/java.py
+++ b/sublimelinter/modules/java.py
@@ -16,6 +16,7 @@ CONFIG = {
 
 ERROR_RE = re.compile(r'^(?P<path>.*\.java):(?P<line>\d+): (?P<warning>warning: )?(?:\[\w+\] )?(?P<error>.*)')
 MARK_RE = re.compile(r'^(?P<mark>\s*)\^$')
+SYMBOL_RE = re.compile(r'^symbol\s*(?P<symbol>:\s*.*)$')
 
 
 class Linter(BaseLinter):
@@ -49,6 +50,11 @@ class Linter(BaseLinter):
 
                 while True:
                     line = it.next()
+                    match = re.match(SYMBOL_RE, line)
+
+                    if match:
+                        error += match.group('symbol')
+
                     match = re.match(MARK_RE, line)
 
                     if match:


### PR DESCRIPTION
attaches the missing symbol to the error message. Helpful for lines with multiple symbols to prevent ambiguity and other packages that want to extract information from SublimeLinter.
