### PR TITLE
Added support for puppet parser warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Following are notes specific to individual linters that you should be aware of:
 
 * **Perl** - Due to a vulnerability (issue [#77](https://github.com/SublimeLinter/SublimeLinter/issues/77)) with the Perl linter, Perl syntax checking is no longer enabled by default. The default linter for Perl has been replaced by Perl::Critic. The standard Perl syntax checker can still be invoked by switching the "perl_linter" setting to "perl".
 
+* **Puppet** - Set "puppet_warnings" setting to `false` to stop warning messages, such as deprecation notices, from being displayed.
+
 * **Ruby** - If you are using rvm or rbenv, you will probably have to specify the full path to the ruby you are using in the "sublimelinter_executable_map" setting. See "Configuring" below for more info.
 
 ### Per-project settings

--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -54,6 +54,7 @@ ALL_SETTINGS = [
     'pep8',
     'pep8_ignore',
     'perl_linter',
+    'puppet_warnings',
     'pyflakes_ignore',
     'pyflakes_ignore_import_*',
     'sublimelinter',

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -213,6 +213,9 @@
     // Objective-J: if true, non-ascii characters are flagged as an error.
     "sublimelinter_objj_check_ascii": false,
 
+    // Puppet: report warnings, such as deprecation notices from puppet parser, set to false to disable.
+    "puppet_warnings": true,
+
     // Set to true to highlight annotations
     "sublimelinter_notes": false,
 


### PR DESCRIPTION
Added puppet parser warnings to puppet linter so we can get depreciation warnings in ST.  Configurable with `puppet_warnings` config option.
