### PR TITLE
Look for .jshintrc in user’s home folder if not found elsewhere. 

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -351,6 +351,15 @@ class BaseLinter(object):
             else:
                 dirname = parent
 
+    def find_file_in_home(self, filename):
+        '''Find a file in the user’s home directory, which can be useful if a
+           file is not found using find_file() above.'''
+        path = os.path.join(os.path.expanduser('~'), filename)
+        if os.path.isfile(path):
+            with open(path, 'r') as f:
+                return f.read()
+        return None
+
     def strip_json_comments(self, json_str):
         stripped_json = JSON_MULTILINE_COMMENT_RE.sub('', json_str)
         stripped_json = JSON_SINGLELINE_COMMENT_RE.sub('', stripped_json)

--- a/sublimelinter/modules/javascript.py
+++ b/sublimelinter/modules/javascript.py
@@ -49,7 +49,12 @@ class Linter(BaseLinter):
 
     def get_javascript_options(self, view):
         if self.linter == 'jshint':
-            rc_options = self.find_file('.jshintrc', view)
+            jshint_config_file = '.jshintrc'
+
+            rc_options = self.find_file(jshint_config_file, view)
+            # As a last resort, look for the file in the user’s home directory.
+            if not rc_options:
+                rc_options = self.find_file_in_home(jshint_config_file)
 
             if rc_options != None:
                 rc_options = self.strip_json_comments(rc_options)


### PR DESCRIPTION
The jshint linter looks for a `.jshintrc` config file in the current file’s directory and all its parents, but with this change the user’s home directory will also be scanned as a last resort. 
