### PR TITLE
Feed file path to the cpplint, not just a string.

### DIFF
--- a/sublimelinter/modules/c_cpplint.py
+++ b/sublimelinter/modules/c_cpplint.py
@@ -3,14 +3,14 @@
 
 import re
 
-from base_linter import BaseLinter, INPUT_METHOD_TEMP_FILE
+from base_linter import BaseLinter, INPUT_METHOD_FILE
 
 CONFIG = {
     'language': 'c_cpplint',
     'executable': 'cpplint.py',
     'test_existence_args': ['--help'],
     'lint_args': '{filename}',
-    'input_method': INPUT_METHOD_TEMP_FILE
+    'input_method': INPUT_METHOD_FILE
 }
 
 


### PR DESCRIPTION
CppLint relies on finding the corresponding header file in the same
directory for some checks. Feeding the string breaks the feature and
is most likely less efficient.
