### PR TITLE
more clear way to import third-party modules

### DIFF
--- a/sublimelinter/loader.py
+++ b/sublimelinter/loader.py
@@ -5,30 +5,15 @@ import glob
 import os
 import os.path
 import sys
+import imp
 
 import modules.base_linter as base_linter
 
-# sys.path appears to ignore individual paths with unicode characters.
-# This means that this lib_path will be ignored for Windows 7 users with
-# non-ascii characters in their username (thus as their home directory).
-#
-# libs_path = os.path.abspath(os.path.join(os.path.dirname(__file__.encode('utf-8')), u'modules', u'libs'))
-#
-# if libs_path not in sys.path:
-#     sys.path.insert(0, libs_path)
+libdir = os.path.abspath(os.path.join(os.path.dirname(__file__), u'modules', u'libs'))
 
-# As a fix for the Windows 7 lib path issue (#181), the individual modules in
-# the `libs` folder can be explicitly imported. This obviously doesn't scale
-# well, but may be a necessary evil until ST2 upgrades its internal Python.
-#
-tmpdir = os.getcwdu()
-os.chdir(os.path.abspath(os.path.join(os.path.dirname(__file__.encode('utf-8')), u'modules', u'libs')))
-
-for mod in [u'capp_lint', u'pep8', u'pyflakes', u'pyflakes.checker', u'pyflakes.messages']:
-    __import__(mod)
+for mod in [u'capp_lint', u'pep8', u'pyflakes']:
+    imp.load_module(mod, *imp.find_module(mod, [libdir]))
     print u'imported {0}'.format(mod)
-
-os.chdir(tmpdir)
 
 
 class Loader(object):


### PR DESCRIPTION
use imp.load_module to import third-party modules - short and transparent way;
tested with non-ascii characters in path.
