### PR TITLE
fix issue with non-ascii characters in path

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -608,7 +608,7 @@ def reload_view_module(view):
     for name, linter in LINTERS.items():
         module = sys.modules[linter.__module__]
 
-        if module.__file__.encode('utf-8') == view.file_name().encode('utf-8'):
+        if module.__file__ == view.file_name().encode(sys.getfilesystemencoding()):
             print 'SublimeLinter: reloading language:', linter.language
             MOD_LOAD.reload_module(module)
             lint_views(linter)


### PR DESCRIPTION
Path to SublimeLinter has Cyrilic symbols, SublimeLinter works but console print is:

``` python
Writing file /C/Users/Кирилица однако/AppData/Roaming/Sublime Text 2/Packages/SublimeLinter/SublimeLinter.py with encoding UTF-8
Traceback (most recent call last):
  File ".\sublime_plugin.py", line 190, in on_post_save
  File ".\sublime_plugin.py", line 154, in run_timed_function
  File ".\sublime_plugin.py", line 189, in <lambda>
  File ".\SublimeLinter.py", line 743, in on_post_save
  File ".\SublimeLinter.py", line 610, in reload_view_module
UnicodeDecodeError: 'ascii' codec can't decode byte 0xcc in position 9: ordinal not in range(128)
```

I've changed 'utf-8' encoding to `sys.getfilesystemencoding();`
`module.__file__` is 'str' and there is no need to encode;
