### PR TITLE
SublimeLinter is linting during typing, possible fix

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -498,8 +498,8 @@ def _delay_queue(timeout, preemptive):
     global __signaled_, __queued_
     now = time.time()
 
-    if not preemptive and now <= __queued_ + 0.01:
-        return  # never delay queues too fast (except preemptively)
+    #if not preemptive and now <= __queued_ + 0.01:
+    #    return  # never delay queues too fast (except preemptively)
 
     __queued_ = now
     _timeout = float(timeout) / 1000


### PR DESCRIPTION
When i'm typing fast, sublime starts stuttering. I see in task manager that php is linting during typing. I've set a delay to 2 seconds. So it should only linting after typing. Is there a reason why fast delayed queues are not allowed? Commenting these 2 lines fix the stuttering issues and php will be called only once after typing and not several times during typing.
