### PR TITLE
Load user settings in ST3

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -627,9 +627,10 @@ def settings_changed():
 
 def reload_settings(view):
     '''Restores user settings.'''
-    settings = sublime.load_settings(__name__ + '.sublime-settings')
-    settings.clear_on_change(__name__)
-    settings.add_on_change(__name__, settings_changed)
+    name = __name__.split('.')[0]
+    settings = sublime.load_settings(name + '.sublime-settings')
+    settings.clear_on_change(name)
+    settings.add_on_change(name, settings_changed)
 
     for setting in ALL_SETTINGS:
         if settings.get(setting) != None:


### PR DESCRIPTION
SublimeLinter tries to fetch settings from a wrong .sublime-settings file, since `__name__` format has changed. 

About the fix: clear_on_change and add_on_change methods seem to be not implemented yet, so no way to check if they are properly set up, but at least initial load should work. Maybe `name = __name__.split('.')[0]` should be changed to `name = __name__.split('.')[1]` (mind the index), if the plugin were to be cloned into non-standard directory.
