### PR TITLE
Add commands for editing preference files

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -38,5 +38,19 @@
         "caption": "SublimeLinter: Reset",
         "command": "sublimelinter_lint",
         "args": {"action": "reset"}
+    },
+    {
+        "caption": "Preferences: SublimeLinter Settings – Default",
+        "command": "open_file", "args":
+        {
+            "file": "${packages}/SublimeLinter/SublimeLinter.sublime-settings"
+        }
+    },
+    {
+        "caption": "Preferences: SublimeLinter Settings – User",
+        "command": "open_file", "args":
+        {
+            "file": "${packages}/User/SublimeLinter.sublime-settings"
+        }
     }
 ]


### PR DESCRIPTION
This adds two commands to the command palette to edit the default and user SublimeLinter preferences.  This saves the user from going 4 menus deep to do the same.

Edit the SublimeLinter user preferences with ⇧⌘P and "lint u".  Edit the SublimeLinter default preferences with ⇧⌘P and "lint d".
