### PR TITLE
Added ruby-lint support

### DIFF
--- a/sublimelinter/modules/ruby-lint.py
+++ b/sublimelinter/modules/ruby-lint.py
@@ -7,6 +7,8 @@ from base_linter import BaseLinter, INPUT_METHOD_TEMP_FILE
 
 CONFIG = {
     'language': 'ruby-lint',
+    'executable': 'ruby-lint',
+    'lint_args': '{filename}',
     'input_method': INPUT_METHOD_TEMP_FILE
 }
 
@@ -15,8 +17,9 @@ class Linter(BaseLinter):
 
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         for line in errors.splitlines():
-            match = re.match(r'^.+:(?P<line>\d+):\s+(?P<error>.+)', line)
+            match = re.match(r'^.+: (?P<type>.+): line (?P<line>\d+), column \d+:\s+(?P<error>.+)', line)
 
             if match:
-                error, line = match.group('error'), match.group('line')
+                error_type, error, line = match.group('type'), match.group('error'), match.group('line')
+                error = '[{0}] {1}'.format(error_type[0].upper(), error)
                 self.add_message(int(line), lines, error, errorMessages)


### PR DESCRIPTION
Requirements:
- `gem install ruby-lint`
- Correct settings

```
{
  "sublimelinter_executable_map":
  {
    "ruby-lint": "<path to ruby-lint>"
  },
  "sublimelinter_syntax_map":
  {
    "Ruby" : "ruby-lint"
  }
}
```
