### PR TITLE
Support new error reporting format in coffeescript

### DIFF
--- a/sublimelinter/modules/coffeescript.py
+++ b/sublimelinter/modules/coffeescript.py
@@ -24,6 +24,9 @@ class Linter(BaseLinter):
             if not match:
                 match = re.match(r'.*?Error: (?P<error>.+) '
                                  r'on line (?P<line>\d+)', line)
+            if not match:
+                match = re.match(r'[^:]+:(?P<line>\d+):\d+: '
+                                 r'error: (?P<error>.+)', line)
 
             if match:
                 line, error = match.group('line'), match.group('error')


### PR DESCRIPTION
Fixes #398 - it seems the coffee -l command has a new way of reporting
errors that the current version of the module does not support, this
change adds a regex to match that new format.
