### PR TITLE
pep8: Add option for max_line_length

### DIFF
--- a/sublimelinter/modules/python.py
+++ b/sublimelinter/modules/python.py
@@ -140,7 +140,7 @@ class Linter(BaseLinter):
 
             return w.messages
 
-    def pep8_check(self, code, filename, ignore=None):
+    def pep8_check(self, code, filename, ignore=None, max_line_length=None):
         messages = []
         _lines = code.split('\n')
 
@@ -176,7 +176,7 @@ class Linter(BaseLinter):
             _ignore = ignore + pep8.DEFAULT_IGNORE.split(',')
 
             options = pep8.StyleGuide(reporter=SublimeLinterReport, ignore=_ignore).options
-            options.max_line_length = pep8.MAX_LINE_LENGTH
+            options.max_line_length = max_line_length or pep8.MAX_LINE_LENGTH
 
             good_lines = [l + '\n' for l in _lines]
             good_lines[-1] = good_lines[-1].rstrip('\n')
@@ -195,7 +195,11 @@ class Linter(BaseLinter):
         errors = []
 
         if view.settings().get("pep8", True):
-            errors.extend(self.pep8_check(code, filename, ignore=view.settings().get('pep8_ignore', [])))
+            errors.extend(self.pep8_check(
+                code, filename,
+                ignore=view.settings().get('pep8_ignore', []),
+                max_line_length=view.settings().get('pep8_max_line_length')
+            ))
 
         pyflakes_ignore = view.settings().get('pyflakes_ignore', None)
         pyflakes_disabled = view.settings().get('pyflakes_disabled', False)


### PR DESCRIPTION
Now you can specify the max line length in pep8 with an option like:

```
{
    "pep8_max_line_length": 120
}
```

See: #218
