### PR TITLE
Fixes issues #376, #366

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -142,7 +142,8 @@ class BaseLinter(object):
             args = [self.executable]
             args.extend(self.test_existence_args)
             subprocess.Popen(args, startupinfo=self.get_startupinfo(),
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()
+                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             shell=os.name == 'nt').communicate()
         except OSError:
             return (False, '"{0}" cannot be found'.format(self.executable))
 
@@ -202,6 +203,7 @@ class BaseLinter(object):
                                        stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT,
+                                       shell=os.name == 'nt',
                                        startupinfo=self.get_startupinfo())
             process.stdin.write(code)
             result = process.communicate()[0]


### PR DESCRIPTION
In Windows SublimeLinter never can find cpplint.py, because 
`subprocess.Popen(['cpplint.py'....`
gives 
`WindowsError: [Error 193] %1 is not a valid Win32 application`
Related to #294 and #288  too.
The solution works for me on Windows 7 x64, ST2 2217, Python 2.7.7 and don't breaks anything on Debian 6, same ST2, Python 2.6.6.
More reliable solution is mentioned in https://github.com/SublimeLinter/SublimeLinter/issues/294#issuecomment-13212377 comment.
