### PR TITLE
Add support for perlcritic severity levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Following are notes specific to individual linters that you should be aware of:
 
 * **Perl** - Due to a vulnerability (issue [#77](https://github.com/SublimeLinter/SublimeLinter/issues/77)) with the Perl linter, Perl syntax checking is no longer enabled by default. The default linter for Perl has been replaced by Perl::Critic. The standard Perl syntax checker can still be invoked by switching the "perl_linter" setting to "perl".
 
+  By default, perlcritic will be run at the "gentle" level. Any of perlcritic's levels can be used by setting the value of "perl_linter_severity" to one of "stern", "harsh", "cruel", or "brutal".
+
 * **Ruby** - If you are using rvm or rbenv, you will probably have to specify the full path to the ruby you are using in the "sublimelinter_executable_map" setting. See "Configuring" below for more info.
 
 ### Per-project settings

--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -59,6 +59,7 @@ ALL_SETTINGS = [
     'pep8',
     'pep8_ignore',
     'perl_linter',
+    'perl_linter_severity',
     'pyflakes_ignore',
     'pyflakes_ignore_import_*',
     'sublimelinter',

--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -224,6 +224,15 @@
     */
     "perl_linter": "perlcritic",
 
+    /*
+        When using perlcritic for Perl linting, the default severity is 5 (gentle).
+        You can specify other levels here. See perlcritic(1) for more information.
+        This setting is ignored when not using perlcritic.
+
+        Available levels: brutal, cruel, harsh, stern, gentle (default)
+    */
+    "perl_linter_severity": "gentle",
+
     // Objective-J: if true, non-ascii characters are flagged as an error.
     "sublimelinter_objj_check_ascii": false,
 

--- a/sublimelinter/modules/perl.py
+++ b/sublimelinter/modules/perl.py
@@ -35,7 +35,8 @@ class Linter(BaseLinter):
         if self.linter == 'perl':
             return ['-c']
         else:
-            return ['--verbose', '8']
+            linter_severity = '--' + view.settings().get('perl_linter_severity', 'gentle')
+            return [linter_severity, '--verbose', '8']
 
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         for line in errors.splitlines():


### PR DESCRIPTION
Add SublimeLinter option "perl_linter_severity". This option can be set to
any of the five levels supported by perlcritic:

```
brutal, cruel, harsh, stern, gentle (default)
```

This option is ignored if perlcritic is not being used.
