### PR TITLE
Configure Perl, CSS and Javascript linters in project settings

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -149,11 +149,13 @@ class BaseLinter(object):
         return (True, 'using "{0}" for executable'.format(self.executable))
 
     def _get_lint_args(self, view, code, filename):
-        if hasattr(self, 'get_lint_args'):
+        settings = view.settings().get('SublimeLinter', {}).get(self.language, {})
+        
+        # presence of linter settings will force default arguments logic
+        if hasattr(self, 'get_lint_args') and not settings:
             return self.get_lint_args(view, code, filename) or []
         else:
             lintArgs = self.lint_args or []
-            settings = view.settings().get('SublimeLinter', {}).get(self.language, {})
 
             if settings:
                 args = settings.get('lint_args', [])


### PR DESCRIPTION
Linters that have their own get_lint_args method (such as Perl, CSS and Javascript) can't be configured with project level settings. The proposed pull request forces the use of the default _get_lint_args for such linters if project level settings for them are available.
