### PR TITLE
Defining window globally to stop jshint errors. Fixes #504. Fixes #506.

### DIFF
--- a/sublimelinter/modules/libs/jshint/linter.js
+++ b/sublimelinter/modules/libs/jshint/linter.js
@@ -1,5 +1,7 @@
 /*jshint node: true */
 /*globals LINTER_PATH load */
+// Define window globally for node to prevent browserify errors
+global.window = {};
 
 var JSHINT = require("./jshint").JSHINT;
 


### PR DESCRIPTION
With the recent move to the [browserified](http://browserify.org/) flavor of [jshint](http://jshint.org/), it introduced an error since one of the node modules it depended on was expecting to be run in the browser (i.e. it was looking for `window` to be defined).

Unfortunately, we are running the browserified version in node. As a result, I have defined `window` on the `node` `global` which stops the error in its tracks.

P.S. It would be great to know why we are using the browserified version and not a node_module. I am guessing for portability but the same could be gained from saving node_modules to the repository.
