### PR TITLE
add fatal error detection support

### DIFF
--- a/sublimelinter/modules/php.py
+++ b/sublimelinter/modules/php.py
@@ -12,7 +12,7 @@ CONFIG = {
 class Linter(BaseLinter):
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         for line in errors.splitlines():
-            match = re.match(r'^Parse error:\s*(?:\w+ error,\s*)?(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
+            match = re.match(r'^(?:Parse error|Fatal error):\s*(?:\w+ error,\s*)?(?P<error>.+?)\s+in\s+.+?\s*line\s+(?P<line>\d+)', line)
 
             if match:
                 error, line = match.group('error'), match.group('line')


### PR DESCRIPTION
The orginal php syntax detection cannot detect fatal errors, this is a fix.
