### PR TITLE
support reading "jshintConfig" from package.json as an alternative for .jshintrc

### DIFF
--- a/sublimelinter/modules/javascript.py
+++ b/sublimelinter/modules/javascript.py
@@ -46,6 +46,13 @@ class Linter(BaseLinter):
 
     def get_javascript_options(self, view):
         if self.linter == 'jshint':
+            pkg_options = self.find_file('package.json', view)
+
+            if pkg_options is not None:
+                pkg_options = json.loads(pkg_options)
+                if pkg_options['jshintConfig']:
+                    return json.dumps(pkg_options['jshintConfig'])
+
             rc_options = self.find_file('.jshintrc', view)
 
             if rc_options is not None:


### PR DESCRIPTION
> If you’re working on an NPM package you don’t need to have a .jshintrc file anymore. Just put your JSHint options into your package.json file as a property named jshintConfig and you’re all set! The format is exactly the same as .jshintrc.

Related links:
http://jshint.com/blog/2013-08-02/npm/
https://raw.github.com/jshint/jshint/master/package.json
https://github.com/jshint/jshint/commit/a2a9d53a9cd4a4342375e45e2c2e3a1a3cb160cb
