### PR TITLE
ST2/ST3 Reconciliation: xrange -> range

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -234,7 +234,7 @@ class BaseLinter(object):
         line = view.full_line(view.text_point(lineno, 0))
         position += line.begin()
 
-        for i in xrange(length):
+        for i in range(length):
             underlines.append(sublime.Region(position + i))
 
     def underline_regex(self, view, lineno, regex, lines, underlines, wordmatch=None, linematch=None):


### PR DESCRIPTION
In Python 3, xrange was renamed to range (more or less). Replacing current calls to xrange with range has almost no affect on memory or performance as the size of the resulting lists being returned are tiny in the context. That is, replacing xrange(1000000000000) with range would use a lot of RAM, but replacing xrange(10) with range will be almost unmeasurable.
