### PR TITLE
ST2/ST3 Reconciliation: iter.next() -> next(iter)

### DIFF
--- a/sublimelinter/modules/java.py
+++ b/sublimelinter/modules/java.py
@@ -45,7 +45,7 @@ class Linter(BaseLinter):
                 position = -1
 
                 while True:
-                    line = it.next()
+                    line = next(it)
                     match = re.match(MARK_RE, line)
 
                     if match:

--- a/sublimelinter/modules/libs/capp_lint.py
+++ b/sublimelinter/modules/libs/capp_lint.py
@@ -428,7 +428,7 @@ class LintChecker(object):
     def next_statement(self, expect_line=False, check_line=True):
         try:
             while True:
-                raw_line = self.sourcefile.next()
+                raw_line = next(self.sourcefile)
                 # strip EOL
                 if raw_line[-1] == '\n':  # ... unless this is the last line which might not have a \n.
                     raw_line = raw_line[:-1]


### PR DESCRIPTION
Python 2.7 supports both formats. Python 3 only supports next(iter).
