### PR TITLE
ST2/ST3 Reconciliation: pick the appropriate io module

### DIFF
--- a/sublimelinter/modules/libs/capp_lint.py
+++ b/sublimelinter/modules/libs/capp_lint.py
@@ -31,7 +31,10 @@ from __future__ import with_statement
 from optparse import OptionParser
 from string import Template
 import cgi
-import cStringIO
+try:
+    import cStringIO as io
+except ImportError:
+    import io
 import os
 import os.path
 import re
@@ -826,7 +829,7 @@ class LintChecker(object):
         self.filesToCheck = []
 
         try:
-            self.sourcefile = cStringIO.StringIO(text)
+            self.sourcefile = io.StringIO(text)
             self.run_file_checks()
         except StopIteration:
             if self.verbose:

--- a/sublimelinter/modules/sublime_pylint.py
+++ b/sublimelinter/modules/sublime_pylint.py
@@ -1,4 +1,7 @@
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import tempfile
 
 try:


### PR DESCRIPTION
Python 2's c?StringIO modules are called io in Python 3. Try to import the Python 2 version as io. If that fails, import the native Python 3 version.
