### PR TITLE
Changed syntaxMap(lc_syntax, '') to syntaxMap.get(lc_syntax, '')

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -372,7 +372,7 @@ def select_linter(view, ignore_disabled=False):
     if syntax in syntaxMap:
         language = syntaxMap.get(syntax, '').lower()
     elif lc_syntax in syntaxMap:
-        language = syntaxMap(lc_syntax, '').lower()
+        language = syntaxMap.get(lc_syntax, '').lower()
     elif lc_syntax in LINTERS:
         language = lc_syntax
 


### PR DESCRIPTION
I was getting this error when trying to use a Capital name in the syntax map. 

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text 3\sublime_plugin.py", line 255, in on_post_save
    callback.on_post_save(v)
  File "C:\Users\tyler.thrailkill\AppData\Roaming\Sublime Text 3\Packages\SublimeLinter\SublimeLinter.py", line 776, in on_post_save
    queue_linter(select_linter(view), view, preemptive=True, event='on_post_save')
  File "C:\Users\tyler.thrailkill\AppData\Roaming\Sublime Text 3\Packages\SublimeLinter\SublimeLinter.py", line 376, in select_linter
    language = syntaxMap(lc_syntax, '').lower()
TypeError: 'dict' object is not callable
```

This shouldn't have been happening, as far as I can understand. Upon changing it to .get, it seemed to resolve the problem.
