### PR TITLE
Python 3.x linter fails to underline undefined identifiers

### DIFF
--- a/sublimelinter/modules/python.py
+++ b/sublimelinter/modules/python.py
@@ -130,15 +130,7 @@ class Linter(BaseLinter):
             return [PythonError(filename, 0, e.args[0])]
         else:
             # Okay, it's syntactically valid.  Now check it.
-            if ignore is not None:
-                old_magic_globals = pyflakes._MAGIC_GLOBALS
-                pyflakes._MAGIC_GLOBALS += ignore
-
-            w = pyflakes.Checker(tree, filename)
-
-            if ignore is not None:
-                pyflakes._MAGIC_GLOBALS = old_magic_globals
-
+            w = pyflakes.Checker(tree, filename, builtins=ignore)
             return w.messages
 
     def pep8_check(self, code, filename, ignore=None):


### PR DESCRIPTION
Hey, I am using this so I want it to work. This works for me. Closes #546.
