### PR TITLE
Add ruby-tailor linting module

### DIFF
--- a/sublimelinter/modules/ruby-tailor.py
+++ b/sublimelinter/modules/ruby-tailor.py
@@ -1,0 +1,28 @@
+import re
+
+from .base_linter import BaseLinter
+
+CONFIG = {
+    'language': 'ruby-tailor',
+    'executable': 'tailor',
+    'lint_args': '{filename}'
+}
+
+
+class Linter(BaseLinter):
+    def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
+        output = errors.splitlines()
+        for index, line in enumerate(output):
+            line_and_column_match = re.match(r'^.+position:  (?P<line>\d+):(?P<column>\d+)', line)
+            if line_and_column_match:
+                # get the message text that's 2 lines ahead
+                message_match = re.match(r'^.+message:   (?P<error>.+)', output[index+2])
+                line = int(line_and_column_match.group('line'))
+                column = int(line_and_column_match.group('column'))
+                error = message_match.group('error')
+
+                if line == '<EOF>':
+                    # Not sure what to do for EOF errors
+                    line = '1'
+                self.add_message(line, lines, error, errorMessages)
+                self.underline_range(view, line, column, errorUnderlines)


### PR DESCRIPTION
This pull request adds a module for `tailor` support.

We use [tailor](https://github.com/turboladen/tailor) on a project for ruby style checking, and this is how I implemented it for our project (we use [rbenv](https://github.com/sstephenson/rbenv)):

https://gist.github.com/burin/b26ca219fb39a25e39f7

I welcome any comments and feedback. I'm not too familiar with Python and the idioms, so style input is appreciated!

/cc @moubry
