### PR TITLE
fixes icon loading for gutter marks

### DIFF
--- a/SublimeLinter.py
+++ b/SublimeLinter.py
@@ -38,7 +38,7 @@ DELAYS = (
 # "alpha", "bright", "dark", "hard" and "simple"
 MARK_THEMES = ('alpha', 'bright', 'dark', 'hard', 'simple')
 # The path to the built-in gutter mark themes
-MARK_THEMES_PATH = os.path.join('..', 'SublimeLinter', 'gutter_mark_themes')
+MARK_THEMES_PATH = os.path.join('Packages', 'SublimeLinter', 'gutter_mark_themes')
 # The original theme for anyone interested the previous minimalist approach
 ORIGINAL_MARK_THEME = {
     'violation': 'dot',
@@ -258,8 +258,10 @@ def add_lint_marks(view, lines, error_underlines, violation_underlines, warning_
                         gutter_mark_image = ORIGINAL_MARK_THEME[lint_type]
                     elif gutter_mark_theme in MARK_THEMES:
                         gutter_mark_image = os.path.join(MARK_THEMES_PATH, gutter_mark_theme + '-' + lint_type)
+                        gutter_mark_image += '.png'
                     else:
                         gutter_mark_image = gutter_mark_theme + '-' + lint_type
+                        gutter_mark_image += '.png'
 
                 args.append(gutter_mark_image)
 


### PR DESCRIPTION
When users clone the Sublime Text 3 branch, I think their gutter icons will be broken, at least they were for me.  This should hopefully fix that.
