### PR TITLE
Added the ability to specify a custom jshint module

### DIFF
--- a/sublimelinter/modules/base_linter.py
+++ b/sublimelinter/modules/base_linter.py
@@ -196,12 +196,18 @@ class BaseLinter(object):
         else:
             return u''
 
+        if hasattr(self, 'get_lint_env'):
+            env = dict(os.environ.items() + self.get_lint_env(view).items())
+        else:
+            env = None;
+
         try:
             process = subprocess.Popen(args,
                                        stdin=subprocess.PIPE,
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT,
-                                       startupinfo=self.get_startupinfo())
+                                       startupinfo=self.get_startupinfo(),
+                                       env=env)
             process.stdin.write(code)
             result = process.communicate()[0]
         finally:

--- a/sublimelinter/modules/javascript.py
+++ b/sublimelinter/modules/javascript.py
@@ -52,6 +52,9 @@ class Linter(BaseLinter):
                 rc_options = self.strip_json_comments(rc_options)
                 return json.dumps(json.loads(rc_options))
 
+    def get_lint_env(self, view):
+        return { 'CUSTOM_%s' % self.linter.upper() : view.settings().get("%s_module" % self.linter, []) };
+
     def parse_errors(self, view, errors, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
         if (self.linter == 'gjslint'):
             ignore = view.settings().get('gjslint_ignore', [])

--- a/sublimelinter/modules/libs/jshint/linter.js
+++ b/sublimelinter/modules/libs/jshint/linter.js
@@ -1,7 +1,7 @@
 /*jshint node: true */
 /*globals LINTER_PATH load */
 
-var JSHINT = require("./jshint").JSHINT;
+var JSHINT = require(process.env.CUSTOM_JSHINT || "./jshint").JSHINT;
 
 exports.lint = function (code, config) {
     var globals,


### PR DESCRIPTION
I'm currently in need of a jshint feature that isn't supported in the version bundled with SublimeLinter. It seems like the versions are somewhat locked, and not customizable so I hacked support (for jshint only) into the plugin.

A "bug" in this code is that the setting is only being read from the global settings for some reason. I didn't figure out how SublimeLinter was accessing it's own setting files.

I have never worked in the sublime plugin environment (or really python for that matter) so if you have the time please let me know how I can fix the mistakes I've made.

Thanks!
