### PR TITLE
Added reStructuredText linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ SublimeLinter has built in linters for the following languages:
 * Puppet - syntax check via `puppet parser validate`
 * Python - native, moderately-complete lint
 * Ruby - syntax check via `ruby -wc`
+* reStructuredText - syntax check via [`rst-lint`](https://pypi.python.org/pypi/restructuredtext_lint)
 * XML - lint via `xmllint`
 
 Quickstart

--- a/sublimelinter/modules/restructuredtext.py
+++ b/sublimelinter/modules/restructuredtext.py
@@ -1,0 +1,20 @@
+import json
+
+from base_linter import BaseLinter
+
+CONFIG = {
+    'language': 'reStructuredText',
+    'executable': 'rst-lint',
+    'lint_args': ['--format', 'json', '{filename}'],
+}
+
+class Linter(BaseLinter):
+    def parse_errors(self, view, error_json, lines, errorUnderlines, violationUnderlines, warningUnderlines, errorMessages, violationMessages, warningMessages):
+        try:
+            errors = json.loads(error_json)
+        except ValueError as e:
+            print('Could not parse rst.')
+            print(error_json)
+            raise e
+        for error in errors:
+            self.add_message(error['line'], lines, error['message'], errorMessages)


### PR DESCRIPTION
I have added a new linter for reStructuredText. Too many times have I released a package to PyPI only to find my reStructuredText wasn't valid. In this PR:
- Add new linter module for [`rst-lint`](https://pypi.python.org/pypi/restructuredtext_lint)
- Add reStructuredText info to README
