### PR TITLE
Rubocop module, take two.

### DIFF
--- a/sublimelinter/modules/rubocop.py
+++ b/sublimelinter/modules/rubocop.py
@@ -1,12 +1,12 @@
 import re
 
-from base_linter import BaseLinter, INPUT_METHOD_TEMP_FILE
+from base_linter import BaseLinter, INPUT_METHOD_FILE
 
 CONFIG = {
     'language': 'rubocop',
     'executable': 'rubocop',
     'lint_args': ['-f','s','{filename}'],
-    'input_method': INPUT_METHOD_TEMP_FILE
+    'input_method': INPUT_METHOD_FILE
 }
 
 


### PR DESCRIPTION
Fixed rubocop arguments which give proper output of linter to parse.
