### PR TITLE
Change sublimelinter setting's default value to "load-save"

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -5,12 +5,12 @@
     /*
         Sets the mode in which SublimeLinter runs:
 
-        true - Linting occurs in the background as you type (the default).
+        true - Linting occurs in the background as you type.
         false - Linting only occurs when you initiate it.
-        "load-save" - Linting occurs only when a file is loaded and saved.
+        "load-save" - Linting occurs only when a file is loaded and saved (the default).
         "save-only" - Linting occurs only when a file is saved.
     */
-    "sublimelinter": true,
+    "sublimelinter": "load-save",
 
     /*
         Maps language names **as listed at the beginning of the README** (but all lowercase)


### PR DESCRIPTION
I'm using a brand-new maxed-out 15" Retina MacBook Pro, and setting `"sublimelinter"` to `true` makes moderate-sized Ruby files slow to edit, and large ones (over 1000 lines) extremely painful. I knew about this setting because I've used and loved Sublime Linter for a long time (thank you so much by the way), but I've had a lot of friends who have complained about it going slow like that on very fast computers too, and didn't know what was causing it.

This branch changes the default `"sublimelinter"` value to `"load-save"`. This speeds up editing Ruby files considerably on my computer.

I haven't used Sublime Linter on large files in any other language so I don't know if the same performance problems exist on them. If this is just a Ruby thing and you'd rather keep this defaulted to `true` for the sake of other languages, I totally understand the tradeoff and will have no complaints :)
