### PR TITLE
To fix bug 'console' is not recognized in jshint

### DIFF
--- a/SublimeLinter.sublime-settings
+++ b/SublimeLinter.sublime-settings
@@ -123,7 +123,8 @@
         "browser": true,
         "wsh": true,
         "trailing": true,
-        "sub": true
+        "sub": true,
+        "devel": true
     },
 
     // A list of command line options to send to gjslint. --nobeep is always sent.


### PR DESCRIPTION
In default configuration, jshint show "console is not defined" because "devel" is disabled. This patch is to fix the problem.
