### PR TITLE
Fix for util.puts deprecated in Node 0.12

### DIFF
--- a/sublimelinter/modules/libs/jsengines/node.js
+++ b/sublimelinter/modules/libs/jsengines/node.js
@@ -5,7 +5,6 @@
     */
 
 var _fs = require('fs'),
-    _util = require('util'),
     _path = require('path'),
     linterPath = process.argv[2].replace(/\/$/, '') + '/',
     _linter = require(linterPath + 'linter');
@@ -18,7 +17,7 @@ function run() {
 
     if (filename) {
         results = _linter.lint(_fs.readFileSync(filename, 'utf-8'), config, linterPath);
-        _util.puts(JSON.stringify(results));
+        console.log(JSON.stringify(results));
     } else {
         process.stdin.resume();
         process.stdin.setEncoding('utf8');
@@ -29,7 +28,7 @@ function run() {
 
         process.stdin.on('end', function () {
             results = _linter.lint(code, config, linterPath);
-            _util.puts(JSON.stringify(results));
+            console.log(JSON.stringify(results));
         });
     }
 }


### PR DESCRIPTION
Fix for #648 : SublimeLinter no longer works with Node 0.12.
util.puts has been deprecated in Node 0.12, and was only a wrapper on console.log before that.

- Removed require of 'util'.
- Replaced calls to util.puts with console.log